### PR TITLE
Homepage Tour does not work #25

### DIFF
--- a/application-forum-ui/pom.xml
+++ b/application-forum-ui/pom.xml
@@ -31,14 +31,10 @@
   <packaging>xar</packaging>
   <name>Forum Application - UI</name>
   <properties>
-    <!-- The list of documents that have an implicit unlimited free license. The users can view these documents without
-      buying a license or getting a trial license, but they cannot edit or delete them. -->
-    <xwiki.extension.licensing.publicDocuments>
-      Forums.WebHome
-    </xwiki.extension.licensing.publicDocuments>
     <xwiki.extension.licensing.excludedDocuments>
       ForumCode.ConfigurationAdmin,
-      Forums.WebPreferences
+      Forums.WebPreferences,
+      Forums.WebHome
     </xwiki.extension.licensing.excludedDocuments>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Forum Application (Pro)</xwiki.extension.name>


### PR DESCRIPTION
The tour is not working because the author does not have edit rights on WebHome. By excluding it,the tour is working without giving to the user to much permissions that could alter the Forums functionalities.