### PR TITLE
Mails sent by Forum should appear in the Mail Sending Status #23

### DIFF
--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -60,14 +60,23 @@
   ## sending email
   #set($emailRegex = "[-0-9a-zA-Z.+_]+@[-0-9a-zA-Z.+_]+\.[a-zA-Z]{2,4}")
   #set($adminEmail = $xwiki.getXWikiPreference('admin_email'))
+  #if ("${adminEmail}" == '')
+    ## Get admin email from global administration settings
+    #set ($configDocName = 'Mail.MailConfig')
+    #set ($configDoc = $xwiki.getDocument($configDocName))
+    #set ($configClassName = 'Mail.SendMailConfigClass')
+    #set ($configObj = $configDoc.getObject($configClassName))
+    #set ($adminEmail = $configObj.from)
+  #end
   #if (!$adminEmail.matches($emailRegex))
     #set($adminEmail = '')
   #end
-  #set($moderator = $flagDoc.getValue('moderator'))
-  #if("$!{moderator}" != '')
-    #set($moderatorEmail = $xwiki.getUserName($moderator, "$email", false))
-    #if(!$moderatorEmail.matches($emailRegex))
-      #set($moderatorEmail = '')
+
+  #set ($moderator = $flagDoc.getValue('moderator'))
+  #if ("$!{moderator}" != '')
+    #set ($moderatorEmail = $xwiki.getUserName($moderator, "$email", false))
+    #if (!$moderatorEmail.matches($emailRegex))
+      #set ($moderatorEmail = '')
     #end
   #end
 
@@ -75,11 +84,22 @@
 
   $services.localization.render('conversations.flag.success.dialog.message')
 
-  #if("$!{adminEmail}" != '' &amp;&amp; "$!{moderatorEmail}" != '')
-    #set($mailTo = "${adminEmail},${moderatorEmail}")
-    #set($url = $flagDoc.getExternalURL())
-    #set($res = $xwiki.mailsender.sendMessageFromTemplate($adminEmail, $mailTo, $util.null, $util.null, '', 'ForumCode.MailTemplateFlag', $xcontext.vcontext))
-    #if ($res != 0)
+  #if ("$!{adminEmail}" != '')
+    #set ($mailTo = "${adminEmail}")
+    #if ("$!{moderatorEmail}" != '')
+      #set ($mailTo = "${mailTo}, {moderatorEmail}")
+    #end
+    ## Create the message to be send
+    #set ($templateReference = $services.model.createDocumentReference('', 'ForumCode', 'MailTemplateFlag'))
+    #set ($configDoc = $xwiki.getDocument($templateReference))
+    #set ($configClassName = 'XWiki.Mail')
+    #set ($configObj = $configDoc.getObject($configClassName))
+    #set ($subject = $configObj.subject)
+    #set ($mailMessage = $services.mailsender.createMessage($mailTo, $subject))
+    #set ($discard = $mailMessage.addPart("xwiki/template", $templateReference, {'velocityVariables' : { 'var1' : 'value1' }}))
+    #set ($res = $services.mailsender.sendAsynchronously([$mailMessage], 'database'))
+    $res.statusResult.waitTillProcessed(10000)
+    #if ($res.statusResult.isProcessed() != true)
       {{warning}}$services.localization.render('conversations.flag.error.nomailsent'){{/warning}}
     #end
   #else

--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -20,19 +20,19 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="ForumCode.NewFlagSheet" locale="">
+<xwikidoc version="1.3" reference="ForumCode.NewFlagSheet" locale="">
   <web>ForumCode</web>
   <name>NewFlagSheet</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <parent>WebHome</parent>
   <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1375308000000</creationDate>
+  <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1375308000000</creationDate>
-  <date>1375308000000</date>
-  <contentUpdateDate>1375308000000</contentUpdateDate>
+  <date>1564736627000</date>
+  <contentUpdateDate>1564736382000</contentUpdateDate>
   <version>1.1</version>
   <title>$services.localization.render("conversations.flag.dialog.header") </title>
   <comment/>
@@ -90,6 +90,7 @@
 
   $services.localization.render('conversations.flag.success.dialog.message')
 
+  ## sending notification email
   #if ($mailTo.size() &gt; 0)
     ## Create the message to be send
     #set ($templateReference = $services.model.createDocumentReference('', 'ForumCode', 'MailTemplateFlag'))
@@ -98,14 +99,13 @@
     #set ($mailMessage = $services.mailsender.createMessage($stringtool.join($mailTo, ', '), $mailObj.subject))
     #set ($discard = $mailMessage.addPart('xwiki/template', $templateReference))
     #set ($res = $services.mailsender.sendAsynchronously([$mailMessage], 'database'))
-    $res.statusResult.waitTillProcessed(10000)
+    #set ($discard = $res.statusResult.waitTillProcessed(10000))
     #if ($res.statusResult.isProcessed() != true)
       {{warning}}$services.localization.render('conversations.flag.error.nomailsent'){{/warning}}
     #end
   #else
     {{warning}}$services.localization.render('conversations.flag.error.nomailsent'){{/warning}}
   #end
-  ## sending notification email
 
   [[$services.localization.render('conversations.flag.success.dialog.goback') &gt;&gt;$request.target]]
 #else

--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -20,19 +20,19 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="ForumCode.NewFlagSheet" locale="">
+<xwikidoc version="1.2" reference="ForumCode.NewFlagSheet" locale="">
   <web>ForumCode</web>
   <name>NewFlagSheet</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
-  <creator>xwiki:XWiki.Admin</creator>
-  <creationDate>1375308000000</creationDate>
   <parent>WebHome</parent>
+  <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1564736627000</date>
-  <contentUpdateDate>1564736382000</contentUpdateDate>
+  <creationDate>1375308000000</creationDate>
+  <date>1375308000000</date>
+  <contentUpdateDate>1375308000000</contentUpdateDate>
   <version>1.1</version>
   <title>$services.localization.render("conversations.flag.dialog.header") </title>
   <comment/>

--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -83,10 +83,10 @@
 
   #set ($mailTo = $collectionstool.set)
   #if ("$!adminEmail" != '')
-    #set ($discard  = $mailTo.add($adminEmail))
+    #set ($discard = $mailTo.add($adminEmail))
   #end
   #if ("$!moderatorEmail" != '')
-    #set ($discard  = $mailTo.add($moderatorEmail))
+    #set ($discard = $mailTo.add($moderatorEmail))
   #end
   #if ($mailTo.size())
     ## Create the message to be send

--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -81,16 +81,19 @@
 
   $services.localization.render('conversations.flag.success.dialog.message')
 
+  #set ($mailTo = $collectionstool.set)
   #if ("$!adminEmail" != '')
-    #set ($mailTo = $adminEmail)
-    #if ("$!moderatorEmail" != '')
-      #set ($mailTo = "$mailTo, $moderatorEmail")
-    #end
+    #set ($discard  = $mailTo.add($adminEmail))
+  #end
+  #if ("$!moderatorEmail" != '')
+    #set ($discard  = $mailTo.add($moderatorEmail))
+  #end
+  #if ($mailTo.size())
     ## Create the message to be send
     #set ($templateReference = $services.model.createDocumentReference('', 'ForumCode', 'MailTemplateFlag'))
     #set ($templateDoc = $xwiki.getDocument($templateReference))
     #set ($mailObj = $templateDoc.getObject('XWiki.Mail'))
-    #set ($mailMessage = $services.mailsender.createMessage($mailTo, $mailObj.subject))
+    #set ($mailMessage = $services.mailsender.createMessage($stringtool.join($mailTo, ', '), $mailObj.subject))
     #set ($discard = $mailMessage.addPart('xwiki/template', $templateReference))
     #set ($res = $services.mailsender.sendAsynchronously([$mailMessage], 'database'))
     $res.statusResult.waitTillProcessed(10000)

--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -60,20 +60,17 @@
   ## sending email
   #set($emailRegex = "[-0-9a-zA-Z.+_]+@[-0-9a-zA-Z.+_]+\.[a-zA-Z]{2,4}")
   #set($adminEmail = $xwiki.getXWikiPreference('admin_email'))
-  #if ("${adminEmail}" == '')
+  #if ($adminEmail == '')
     ## Get admin email from global administration settings
-    #set ($configDocName = 'Mail.MailConfig')
-    #set ($configDoc = $xwiki.getDocument($configDocName))
-    #set ($configClassName = 'Mail.SendMailConfigClass')
-    #set ($configObj = $configDoc.getObject($configClassName))
+    #set ($configDoc = $xwiki.getDocument('Mail.MailConfig'))
+    #set ($configObj = $configDoc.getObject('Mail.SendMailConfigClass'))
     #set ($adminEmail = $configObj.from)
   #end
   #if (!$adminEmail.matches($emailRegex))
     #set($adminEmail = '')
   #end
-
   #set ($moderator = $flagDoc.getValue('moderator'))
-  #if ("$!{moderator}" != '')
+  #if ("$!moderator" != '')
     #set ($moderatorEmail = $xwiki.getUserName($moderator, "$email", false))
     #if (!$moderatorEmail.matches($emailRegex))
       #set ($moderatorEmail = '')
@@ -84,19 +81,17 @@
 
   $services.localization.render('conversations.flag.success.dialog.message')
 
-  #if ("$!{adminEmail}" != '')
-    #set ($mailTo = "${adminEmail}")
-    #if ("$!{moderatorEmail}" != '')
-      #set ($mailTo = "${mailTo}, {moderatorEmail}")
+  #if ("$!adminEmail" != '')
+    #set ($mailTo = $adminEmail)
+    #if ("$!moderatorEmail" != '')
+      #set ($mailTo = "$mailTo, $moderatorEmail")
     #end
     ## Create the message to be send
     #set ($templateReference = $services.model.createDocumentReference('', 'ForumCode', 'MailTemplateFlag'))
-    #set ($configDoc = $xwiki.getDocument($templateReference))
-    #set ($configClassName = 'XWiki.Mail')
-    #set ($configObj = $configDoc.getObject($configClassName))
-    #set ($subject = $configObj.subject)
-    #set ($mailMessage = $services.mailsender.createMessage($mailTo, $subject))
-    #set ($discard = $mailMessage.addPart("xwiki/template", $templateReference, {'velocityVariables' : { 'var1' : 'value1' }}))
+    #set ($templateDoc = $xwiki.getDocument($templateReference))
+    #set ($mailObj = $templateDoc.getObject('XWiki.Mail'))
+    #set ($mailMessage = $services.mailsender.createMessage($mailTo, $mailObj.subject))
+    #set ($discard = $mailMessage.addPart('xwiki/template', $templateReference))
     #set ($res = $services.mailsender.sendAsynchronously([$mailMessage], 'database'))
     $res.statusResult.waitTillProcessed(10000)
     #if ($res.statusResult.isProcessed() != true)

--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -88,7 +88,7 @@
   #if ("$!moderatorEmail" != '')
     #set ($discard = $mailTo.add($moderatorEmail))
   #end
-  #if ($mailTo.size())
+  #if ($mailTo.size() &gt; 0)
     ## Create the message to be send
     #set ($templateReference = $services.model.createDocumentReference('', 'ForumCode', 'MailTemplateFlag'))
     #set ($templateDoc = $xwiki.getDocument($templateReference))

--- a/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/NewFlagSheet.xml
@@ -66,14 +66,23 @@
     #set ($configObj = $configDoc.getObject('Mail.SendMailConfigClass'))
     #set ($adminEmail = $configObj.from)
   #end
+
+  ## mailTo contains email addresses at which the email notification will be send.
+  #set ($mailTo = $collectionstool.set)
+
   #if (!$adminEmail.matches($emailRegex))
     #set($adminEmail = '')
+  #else
+    #set ($discard = $mailTo.add($adminEmail))
   #end
+
   #set ($moderator = $flagDoc.getValue('moderator'))
   #if ("$!moderator" != '')
     #set ($moderatorEmail = $xwiki.getUserName($moderator, "$email", false))
     #if (!$moderatorEmail.matches($emailRegex))
       #set ($moderatorEmail = '')
+    #else
+       #set ($discard = $mailTo.add($moderatorEmail))
     #end
   #end
 
@@ -81,13 +90,6 @@
 
   $services.localization.render('conversations.flag.success.dialog.message')
 
-  #set ($mailTo = $collectionstool.set)
-  #if ("$!adminEmail" != '')
-    #set ($discard = $mailTo.add($adminEmail))
-  #end
-  #if ("$!moderatorEmail" != '')
-    #set ($discard = $mailTo.add($moderatorEmail))
-  #end
   #if ($mailTo.size() &gt; 0)
     ## Create the message to be send
     #set ($templateReference = $services.model.createDocumentReference('', 'ForumCode', 'MailTemplateFlag'))


### PR DESCRIPTION
Used sendAsynchronously insead of sendMessageFromTemplate for store the status of email in database.

`sendMessageFromTemplate` is not offering the possibility of storing the status of email in database, so it will not be retrieved in Mail Sending Status page.