### PR TITLE
Issue #52: Share on facebook feature returns an error

### DIFF
--- a/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
@@ -39,8 +39,8 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="Licenses.Code.VelocityMacros"/}}
-
+  <content>{{include reference='Licenses.Code.VelocityMacros'/}}
+{{include reference='ForumCode.Macros' /}}
 {{velocity}}
 #set ($mainReference = $services.model.createDocumentReference('', 'ForumCode', 'ConfigurationClass'))
 #if (!$services.licensing.licensor.hasLicensureForEntity($mainReference))
@@ -48,12 +48,14 @@
   {{error}}#getMissingLicenseMessage('forum.extension.name'){{/error}}
 
 #else
-  {{include reference="ForumCode.FlagsHome"/}}
-
+  {{include reference='ForumCode.FlagsHome'/}}
   == $services.localization.render('forum.administration.configuration.title') ==
+  #checkIfHostNameIsValid($doc.getExternalURL(), $result)
+  #if ($result == 'false')
+    {{warning}}$services.localization.render('forum.administration.warningMessage'){{/warning}}
+  #end
 #end
-{{/velocity}}
-</content>
+{{/velocity}}</content>
   <object>
     <name>ForumCode.ConfigurationAdmin</name>
     <number>0</number>

--- a/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
@@ -39,7 +39,7 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference='Licenses.Code.VelocityMacros'/}}
+  <content>{{include reference="Licenses.Code.VelocityMacros"/}}
 {{include reference='ForumCode.Macros'/}}
 {{velocity}}
 #set ($mainReference = $services.model.createDocumentReference('', 'ForumCode', 'ConfigurationClass'))

--- a/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
@@ -41,6 +41,7 @@
   <hidden>true</hidden>
   <content>{{include reference="Licenses.Code.VelocityMacros"/}}
 {{include reference='ForumCode.Macros'/}}
+
 {{velocity}}
 #set ($mainReference = $services.model.createDocumentReference('', 'ForumCode', 'ConfigurationClass'))
 #if (!$services.licensing.licensor.hasLicensureForEntity($mainReference))
@@ -49,10 +50,11 @@
 
 #else
   {{include reference='ForumCode.FlagsHome'/}}
+
   == $services.localization.render('forum.administration.configuration.title') ==
-  #checkIfHostNameIsValid($doc.getExternalURL(), $result)
+  #checkIfURLCanBeShared($doc.getExternalURL(), $result)
   #if ($result == 'false')
-    {{warning}}$services.localization.render('forum.administration.warningMessage'){{/warning}}
+    {{warning}}$services.localization.render('forum.administration.cannotShareURLWarning'){{/warning}}
   #end
 #end
 {{/velocity}}</content>

--- a/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/ConfigurationAdmin.xml
@@ -40,7 +40,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{include reference='Licenses.Code.VelocityMacros'/}}
-{{include reference='ForumCode.Macros' /}}
+{{include reference='ForumCode.Macros'/}}
 {{velocity}}
 #set ($mainReference = $services.model.createDocumentReference('', 'ForumCode', 'ConfigurationClass'))
 #if (!$services.licensing.licensor.hasLicensureForEntity($mainReference))

--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -480,8 +480,8 @@
 #end
 ##
 #macro(checkIfURLCanBeShared $stringURL $result)
-  ## getUrl is available from 12.8RC1
-  #set ($hostName = $urltool.getUrl($stringURL).getHost())
+  ## toURL is available from 12.9RC1
+  #set ($hostName = $urltool.toURL($stringURL).getHost())
   #if (!$hostName)
     #set ($hostName = $stringURL.split('//')[1].split('/')[0].split(':')[0])
   #end

--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -479,10 +479,24 @@
   #end
 #end
 ##
+#macro(checkIfHostNameIsValid $stringURL $result)
+  ## @since 12.8RC1
+  #set ($hostName = $urltool.getURLFromString($stringURL).getHost())
+  #if (!$hostName)
+    #set ($hostName = $stringURL.split('//')[1].split('/')[0].split(':')[0])
+  #end
+  #if ($hostName.contains('.'))
+    #set ($result = true)
+  #else
+    #set ($result = false)
+  #end
+#end
+##
 #macro(displayForumAddThis $topicDoc, $topicTitle)
   #set ($configDoc = $xwiki.getDocument('ForumCode.ConfigurationAdmin'))
   #set ($configObj = $configDoc.getObject('ForumCode.ConfigurationClass'))
-  #if ($configObj.getValue('enableSocialButtons') == 1)
+  #checkIfHostNameIsValid($topicDoc.getExternalURL(), $result)
+  #if ($configObj.getValue('enableSocialButtons') == 1 &amp;&amp; $result == 'true')
     #set ($addThisTitle = $services.localization.render('conversations.addthis.title', [$topicTitle, $topicDoc.getExternalURL()]))
     #set ($addThisDesc = $services.localization.render('conversations.addthis.desc', [$topicTitle, $topicDoc.getExternalURL()]))
     &lt;div class="topic-addthis"&gt;

--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -480,15 +480,15 @@
 #end
 ##
 #macro(checkIfHostNameIsValid $stringURL $result)
-  ## @since 12.8RC1
+  ## getURLFromString is available from 12.8RC1
   #set ($hostName = $urltool.getURLFromString($stringURL).getHost())
   #if (!$hostName)
     #set ($hostName = $stringURL.split('//')[1].split('/')[0].split(':')[0])
   #end
   #if ($hostName.contains('.'))
-    #set ($result = true)
+    #setVariable('$result', 'true')
   #else
-    #set ($result = false)
+    #setVariable('$result', 'false')
   #end
 #end
 ##

--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -479,9 +479,9 @@
   #end
 #end
 ##
-#macro(checkIfHostNameIsValid $stringURL $result)
-  ## getURLFromString is available from 12.8RC1
-  #set ($hostName = $urltool.getURLFromString($stringURL).getHost())
+#macro(checkIfURLCanBeShared $stringURL $result)
+  ## getUrl is available from 12.8RC1
+  #set ($hostName = $urltool.getUrl($stringURL).getHost())
   #if (!$hostName)
     #set ($hostName = $stringURL.split('//')[1].split('/')[0].split(':')[0])
   #end
@@ -495,7 +495,7 @@
 #macro(displayForumAddThis $topicDoc, $topicTitle)
   #set ($configDoc = $xwiki.getDocument('ForumCode.ConfigurationAdmin'))
   #set ($configObj = $configDoc.getObject('ForumCode.ConfigurationClass'))
-  #checkIfHostNameIsValid($topicDoc.getExternalURL(), $result)
+  #checkIfURLCanBeShared($topicDoc.getExternalURL(), $result)
   #if ($configObj.getValue('enableSocialButtons') == 1 &amp;&amp; $result == 'true')
     #set ($addThisTitle = $services.localization.render('conversations.addthis.title', [$topicTitle, $topicDoc.getExternalURL()]))
     #set ($addThisDesc = $services.localization.render('conversations.addthis.desc', [$topicTitle, $topicDoc.getExternalURL()]))

--- a/application-forum-ui/src/main/resources/ForumCode/Translations.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Translations.xml
@@ -295,7 +295,8 @@ templateProvider.forum.name=Forum
 templateProvider.forum.description=Start a conversation
 
 ## Forum Administration Section
-forum.administration.configuration.title=Configuration</content>
+forum.administration.configuration.title=Configuration
+forum.administration.warningMessage=It seems like you're trying to access this instance locally.\nThis functionally works only for valid (extern) hosts.</content>
   <object>
     <name>ForumCode.Translations</name>
     <number>0</number>

--- a/application-forum-ui/src/main/resources/ForumCode/Translations.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Translations.xml
@@ -296,7 +296,7 @@ templateProvider.forum.description=Start a conversation
 
 ## Forum Administration Section
 forum.administration.configuration.title=Configuration
-forum.administration.warningMessage=It seems like you're trying to access this instance locally.\nThis functionally works only for valid (extern) hosts.</content>
+forum.administration.cannotShareURLWarning=It seems like you're accessing this instance through localhost. This will prevent you from sharing URLs on social media.</content>
   <object>
     <name>ForumCode.Translations</name>
     <number>0</number>


### PR DESCRIPTION
*check if the hostname is valid
*added a warning message in the administration page when the host is not valid