### PR TITLE
Topics and answers cannot be voted anymore #106

### DIFF
--- a/application-forum-ui/src/main/resources/ForumCode/JavascriptExtension.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/JavascriptExtension.xml
@@ -742,7 +742,7 @@ viewers.Comments = Class.create({
     }
   },
   addConversationLikeListener : function() {
-    var conversationLike = this.conversation.down('.conversation-like img.canVote');
+    var conversationLike = this.conversation.down('.conversation-like');
     // if there is no clickable button, return, don't do anything
     if (!conversationLike) {
       return;
@@ -803,14 +803,15 @@ function conversationLikeHandler(event) {
       var scoreDisplayer = topicLikeBlock.down('.conversation-score');
       if (scoreDisplayer) {
         scoreDisplayer.update(response.responseJSON.totalvotes);
+        var scoreTitle = scoreDisplayer.title;
+        var matches = scoreTitle.match(/\d+/g);
+        var noVotes = parseInt(matches[0]) + parseInt(response.responseJSON.totalvotes);
+        scoreDisplayer.title = scoreTitle.replace(matches[0], noVotes)
       }
       // and now remove this listener from the like button, since the current user shouldn't be able to vote again ...
-      var topicLikeButton = topicLikeBlock.down('img');
-      if (topicLikeButton) {
-        topicLikeButton.stopObserving('click');
-        // ... and put inactive class to change the style
-        topicLikeButton.removeClassName('canVote');
-      }
+      topicLikeBlock.stopObserving('click');
+      // ... and put inactive class to change the style
+      topicLikeBlock.removeClassName('allow-vote')
     }.bind(this),
     onFailure : function (response) {
       var failureReason = response.responseText;

--- a/application-forum-ui/src/main/resources/ForumCode/JavascriptExtension.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/JavascriptExtension.xml
@@ -805,8 +805,7 @@ function conversationLikeHandler(event) {
         scoreDisplayer.update(response.responseJSON.totalvotes);
         var scoreTitle = scoreDisplayer.title;
         var matches = scoreTitle.match(/\d+/g);
-        var noVotes = parseInt(matches[0]) + parseInt(response.responseJSON.totalvotes);
-        scoreDisplayer.title = scoreTitle.replace(matches[0], noVotes)
+        scoreDisplayer.title = scoreTitle.replace(matches[0], response.responseJSON.totalvotes)
       }
       // and now remove this listener from the like button, since the current user shouldn't be able to vote again ...
       topicLikeBlock.stopObserving('click');

--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -611,7 +611,10 @@
 ##
 #macro (displayVoteButton $documentReference)
   ## An user can vote only if didn't already vote and if is authenticated.
-  #set ($canVote = ($services.ratings.getRating($documentReference, $xcontext.userReference) == $util.null) &amp;&amp; !$isGuest)
+  #set ($pageRating = $services.ratings.getRating($documentReference, $xcontext.userReference))
+  ## On newer versions of services.ratings, the API returns an Optional object, thus we also have to check if the
+  ## object is empty or it returned a value.
+  #set ($canVote = ($pageRating == $util.null || $pageRating.isPresent() == false) &amp;&amp; !$isGuest)
   #set ($voteButtonTitleKey = 'conversation.like.button.alreadyliked.tooltip')
   #if ($canVote)
     #set ($voteAllowedClass = 'allow-vote')
@@ -619,6 +622,11 @@
   #end
   &lt;div class="topic-vote $!voteAllowedClass conversation-like" title="$services.localization.render($voteButtonTitleKey)"&gt;
     #set ($rating = $services.ratings.getAverageRating($documentReference).nbVotes)
+    ## In newer versions, services.ratings returns Optional values to most of its functions so we have to retrieve the
+    ## value accordingly.
+    #if ("$!rating" == '')
+      #set ($rating = $services.ratings.getAverageRating($documentReference).get().getNbVotes())
+    #end
     &lt;input type="hidden" name="documenttolike" value="$escapetool.xml($documentReference)" /&gt;
     &lt;span class="conversation-score" title="$services.localization.render('conversation.like.score.tooltip', [$rating])"&gt;$!rating&lt;/span&gt;
   &lt;/div&gt;

--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -614,7 +614,7 @@
   #if (!$isGuest)
       ## An user can vote only if didn't already vote and if is authenticated.
       #set ($pageRating = $services.ratings.getRating($documentReference, $xcontext.userReference))
-      ## On newer versions of services.ratings, the API returns an Optional object, thus we also have to check if the
+      ## Since version 12.9 of services.ratings, the API returns an Optional object, thus we also have to check if the
       ## object is empty or it returned a value.
       #set ($canVote = ($pageRating == $util.null || $pageRating.isPresent() == false))
   #end

--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -610,22 +610,26 @@
 #end
 ##
 #macro (displayVoteButton $documentReference)
-  ## An user can vote only if didn't already vote and if is authenticated.
-  #set ($pageRating = $services.ratings.getRating($documentReference, $xcontext.userReference))
-  ## On newer versions of services.ratings, the API returns an Optional object, thus we also have to check if the
-  ## object is empty or it returned a value.
-  #set ($canVote = ($pageRating == $util.null || $pageRating.isPresent() == false) &amp;&amp; !$isGuest)
+  #set ($canVote = false)
+  #if (!$isGuest)
+      ## An user can vote only if didn't already vote and if is authenticated.
+      #set ($pageRating = $services.ratings.getRating($documentReference, $xcontext.userReference))
+      ## On newer versions of services.ratings, the API returns an Optional object, thus we also have to check if the
+      ## object is empty or it returned a value.
+      #set ($canVote = ($pageRating == $util.null || $pageRating.isPresent() == false))
+  #end
+
   #set ($voteButtonTitleKey = 'conversation.like.button.alreadyliked.tooltip')
   #if ($canVote)
     #set ($voteAllowedClass = 'allow-vote')
     #set ($voteButtonTitleKey = 'conversation.like.button.tooltip')
   #end
   &lt;div class="topic-vote $!voteAllowedClass conversation-like" title="$services.localization.render($voteButtonTitleKey)"&gt;
-    #set ($rating = $services.ratings.getAverageRating($documentReference).nbVotes)
-    ## In newer versions, services.ratings returns Optional values to most of its functions so we have to retrieve the
-    ## value accordingly.
+    ## Use the latest API
+    #set ($rating = $services.ratings.getAverageRating($documentReference).get().getNbVotes())
+    ## For versions before 12.9 we need to use the old API.
     #if ("$!rating" == '')
-      #set ($rating = $services.ratings.getAverageRating($documentReference).get().getNbVotes())
+      #set ($rating = $services.ratings.getAverageRating($documentReference).nbVotes)
     #end
     &lt;input type="hidden" name="documenttolike" value="$escapetool.xml($documentReference)" /&gt;
     &lt;span class="conversation-score" title="$services.localization.render('conversation.like.score.tooltip', [$rating])"&gt;$!rating&lt;/span&gt;

--- a/application-forum-ui/src/main/resources/ForumCode/Ratings.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Ratings.xml
@@ -38,12 +38,16 @@
   <hidden>true</hidden>
   <content>{{velocity}}
 #set ($discard = $response.setContentType('application/json'))
-#set ($docRef = $request.docRef)
+#set ($docRef = $services.model.resolveDocument($request.docRef))
 #if (!$isGuest &amp;&amp; "$!{request.vote}" == '1')
-  #set ($discard = $services.ratings.setRating($docRef, $xcontext.user, 1))
+  #set ($discard = $services.ratings.setRating($docRef, $xcontext.userReference, 1))
 #end
 #set ($avgRating = $services.ratings.getAverageRating($docRef))
 #set ($nbVotes = $avgRating.nbVotes)
+## Newer versions of services.ratings API return Optional objects so we have to retrieve the value from within.
+#if ("$!nbVotes" == '')
+  #set ($nbVotes = $avgRating.get().getNbVotes())
+#end
 $jsontool.serialize({'totalvotes' : "$!{nbVotes}"})
 {{/velocity}}</content>
 </xwikidoc>

--- a/application-forum-ui/src/main/resources/ForumCode/Ratings.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Ratings.xml
@@ -43,10 +43,11 @@
   #set ($discard = $services.ratings.setRating($docRef, $xcontext.userReference, 1))
 #end
 #set ($avgRating = $services.ratings.getAverageRating($docRef))
-#set ($nbVotes = $avgRating.nbVotes)
-## Newer versions of services.ratings API return Optional objects so we have to retrieve the value from within.
+## Use the latest API
+#set ($nbVotes = $avgRating.get().getNbVotes())
+## For versions before 12.9 we need to use the old API.
 #if ("$!nbVotes" == '')
-  #set ($nbVotes = $avgRating.get().getNbVotes())
+  #set ($nbVotes = $avgRating.nbVotes)
 #end
 $jsontool.serialize({'totalvotes' : "$!{nbVotes}"})
 {{/velocity}}</content>


### PR DESCRIPTION
While investigating this issue I found out that the voting also failed on older versions of XWiki.

On the older versions, the reason the vote failed was because there was a conflict in converting the parameters passed to the Ratings API through `services.ratings`. Making sure we always passed a document reference to the functions fixed the issue. 

On the newer versions, the Ratings API had changed and thus the function calls inside our application were no longer valid. So I had to make changes to the code for it to work on both APIs.

Moreover, I made some small code changes to the JavaScript code. The click listener wasn't properly removed from the vote button after voting. The html title associated with the vote button wasn't updated after voting.
