### PR TITLE
The number of likes don't appear anymore in the Most Active Topics #113

### DIFF
--- a/application-forum-ui/src/main/resources/ForumCode/Macros.xml
+++ b/application-forum-ui/src/main/resources/ForumCode/Macros.xml
@@ -782,7 +782,13 @@
         #set ($topicDoc = $xwiki.getDocument($topic))  
         #if ($topicDoc)
           #set ($topicTitle = $topicDoc.title)
-          #set ($rating = $services.ratings.getAverageRating($topicReference).nbVotes)
+          #set ($avgRating = $services.ratings.getAverageRating($topicDoc))
+          ## Use the latest API
+          #set ($nbVotes = $avgRating.get().getNbVotes())
+          ## For versions before 12.9 we need to use the old API.
+          #if ("$!nbVotes" == '')
+            #set ($nbVotes = $avgRating.nbVotes)
+          #end
           #set ($topicComments = 0)
           #set ($topicAnswers = [])
           #getTopicAnswers($topicDoc.space $topicAnswers)
@@ -802,7 +808,7 @@
           #end
           &lt;tr class="${topicodd}"&gt;
             &lt;td class="topic"&gt;&lt;a href="$topicDoc.getURL()"&gt;$!topicTitle&lt;/a&gt;&lt;/td&gt;
-            &lt;td class="votes"&gt;$!rating&lt;/td&gt;
+            &lt;td class="votes"&gt;$!nbVotes&lt;/td&gt;
             &lt;td class="comments"&gt;$!nbCommentsAnswers&lt;/td&gt;
           &lt;/tr&gt;
         #end


### PR DESCRIPTION
* Copy/paste same logic from Rating page in order to display ratings/votes on panel, before it wasn't finished.

Before changes (votes were made by 2 different users)
![77lXuF8ZCc](https://github.com/xwikisas/application-forum/assets/56109799/2cec9590-c586-4caa-aacb-bd85454663d7)

AFter, votes are present on the Forum topic page and Forum home page. I created an extra topic that was voted by one user. 
![x2TOSnp4Ig](https://github.com/xwikisas/application-forum/assets/56109799/d455d8f2-bba9-458c-a1ad-afe9ca52e9c0)

Closes #113 
